### PR TITLE
Use witch to locate local binaries

### DIFF
--- a/bin/tasks.js
+++ b/bin/tasks.js
@@ -1,15 +1,17 @@
 'use strict';
 
+const witch = require('witch');
 const path = require('path');
 const cwd = process.cwd();
 const target = path.resolve(cwd, 'public');
 const source = path.resolve(__dirname, '../src');
-const npmsass = require('witch')('npm-sass');
+const npmsass = witch('npm-sass');
+const browserify = witch('browserify');
 
 // jscs:disable maximumLineLength
 module.exports = {
   'make-folders': `mkdir -p ${target}/js ${target}/css ${target}/images`,
-  'compile-css': `npmsass ${source}/scss/app.scss > ${target}/css/app.css`,
-  'bundle-js': `browserify ${source}/js/index.js > ${target}/js/bundle.js`,
+  'compile-css': `${npmsass} ${source}/scss/app.scss > ${target}/css/app.css`,
+  'bundle-js': `${browserify} ${source}/js/index.js > ${target}/js/bundle.js`,
   'copy-images': `cp -r ${source}/images ${target}`
 };


### PR DESCRIPTION
npm-sass and browserify binaries should be located within the local dependencies and not source from PATH. Otherwise the build script will fail when these are not installed as global deps.

Additionally fixes a missing template placeholder in sass compile command.