### PR TITLE
Add a conditional travis task to only run snyk-protect on master (#2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+script: npm run ci
+conditions:
+  branch:master: npm test && npm run snyk-protect
+  default: npm test

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint": "eslint .",
     "style": "jscs .",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "ci": "travis-conditions"
   },
   "dependencies": {
     "async": "^2.1.4",
@@ -68,6 +69,7 @@
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
     "snyk": "^1.22.1",
+    "travis-conditions": "0.0.0",
     "watchify": "^3.7.0"
   },
   "pre-commit": [


### PR DESCRIPTION
This commit got lost, PR'ing again.

Lenny's original commit message........

* Add a conditional travis task to only run snyk-protect on master

A failing run of snyk-protect should not prevent the merging of PRs and so should not cause a PR to fail, but should result in the overall failing of a master build.

* Add missing script param in travis yml

* Make CI script independent of npm install locations